### PR TITLE
Manifest for import onto Adobe I/O Website

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -1,0 +1,27 @@
+{
+	"name": "XMP (Extensible Metadata Platform) Documentation",
+	"version": "1.0.0",
+	"description": "XMP Documentation",
+	"author": "Emily Walpole",
+	"view_type": "mdbook",
+	"meta_keywords": "adobe, xmp, docs, extensible, metadata, platform",
+	"meta_description": "default description",
+	"publish_date": "10/07/2018",
+	"show_edit_github_banner": false,
+	"base_path": "https://raw.githubusercontent.com",
+	"pages": 
+      [
+        {
+          "importedFileName": "",
+          "pages": [ ],
+          "path": "",
+          "title": ""
+        },
+        {
+          "importedFileName": "",
+          "pages": [ ],
+          "path": "",
+          "title": ""
+        }
+	    ]
+}


### PR DESCRIPTION
Mandatory for onboarding to Adobe I/O Website.
Lists all of the files to be public on the website in order, up to 3 levels of nesting.
Uses showdownjs for conversion from md to html.

Will add file structure in following commits.