### PR TITLE
Example of anchor format

### DIFF
--- a/XMPNamespaces/XMPDataTypes/CoreProperties.md
+++ b/XMPNamespaces/XMPDataTypes/CoreProperties.md
@@ -4,11 +4,11 @@ This page defines a collection of XMP properties that have broad applicability a
 
 ## Basic value type
 
-1.  **Boolean**<a name="Boolean"></a>
+1.  ### Boolean
 
     Boolean values shall be "**True**" or "**False**".
 
-2.  **Date**<a name="Date"></a>
+2.  ### Date
 
     A date-time value is represented using a subset of the formats as defined in Date and Time Formats:  
 
@@ -35,23 +35,23 @@ This page defines a collection of XMP properties that have broad applicability a
 
     __NOTE__ : If a file was saved at noon on October 23, a timestamp of 2004-10-23T12:00:00-06:00 conveys more information than 2004-10-23T18:00:00Z.
 
-3.  **Integer**<a name="Integer"></a>
+3.  ### Integer
 
     A signed or unsigned numeric string used as an integer number representation. The string consists of an arbitrary-length decimal numeric string with an optional leading “+” or “–” sign.
 
-4.  **Real**<a name="Real"></a>
+4.  ### Real
 
     A simple text value denoting a floating-point numeric value, written using decimal notation of an optional sign followed by an integer part and a fraction part. Either the integer part or the fraction part, but not both, may be omitted. The sign, if present, is "+" (U+002B) or "-" (U+002D). The integer part, if present, is a sequence of one or more decimal digits (U+0030 to U+0039). The fraction, if present, is a decimal point (".", U+002E) followed by a sequence of one or more decimal digits.  
 
     The precise range and precision for the general type are not specified by this document. If converted to a binary value, an XMP processor shall support at least the 32-bit IEEE 754 range and precision, and it should support at least the 64-bit IEEE 754 range and precision. A particular use of the Real type may specify a required range or precision, such as nonnegative or microsecond resolution (for a duration in seconds).
 
-5.  **Text**<a name="Text"></a>
+5.  ### Text
 
     A possibly empty Unicode string.
 
 ## Derived value type
 
-1.  **AgentName**<a name="AgentName"></a>
+1.  ### Agent Name
 
     The name of an XMP processor, a _Text_ value. It is recommended that the value use this format convention:It is recommended that the value use this format convention:  
 
@@ -64,7 +64,7 @@ This page defines a collection of XMP properties that have broad applicability a
 
         **EXAMPLE**: _"Adobe Acrobat 9.0 (Mac OS X 10.5)"_
 
-2.  **Choice**<a name="Choice"></a>
+2.  ### Choice
 
     A value chosen from a vocabulary of values. Vocabularies provide a means of specifying a limited and possibly extensible set of values for a property.  
 
@@ -74,29 +74,29 @@ This page defines a collection of XMP properties that have broad applicability a
     *   A closed choice has one or more lists of allowed values, other values shall not be used.  
     __NOTE__ An XMP reader would be more robust if it tolerated unexpected values for closed choice types when the set of allowed values can be expected to grow over time.
     
-3.  **GUID**<a name="GUID"></a>
+3.  ### GUID
 
     A string representing a “globally unique identifier”. A GUID shall be a normal (non-URI) simple value, even though it might appear similar to a URI string. This document does not require any particular methodology for creating a GUID, nor does it require any specific means of formatting the GUID as a simple XMP value. The only valid operations on GUIDs are to create them, to assign one to another, and to compare two of them for equality. This comparison shall use the Unicode string value as-is, using a direct byte-for-byte check for equality.
 
-4.  **Language Alternative**<a name="LanguageAlternative"></a>
+4.  ### Language Alternative
 
     An alternative array of simple text items. Language alternatives facilitate the selection of a simple text item based on a desired language. Each array item shall have an xml:lang qualifier. Each xml:lang value shall be unique among the items. As defined in IETF RFC 3066, the xml:lang value is composed of one or more parts: a primary language subtag and a (possibly empty) series of subsequent subtags. The same primary subtag may be used alone and in conjunction with one or more lower-level subtags. A default value, if known, should be the first array item. The order of other array items is not specified by this document.  
 
     An xml:lang value of "x-default" may be used to explicitly denote a default item. If used, the "x-default" item shall be first in the array and its simple text value should be repeated in another item in which xml:lang specifies its actual language. However, an "x-default" item may be the only item, in which case there is only a default value in no defined language.
 
-5.  **Locale**<a name="Locale"></a>
+5.  ### Locale
 
     A simple text value denoting a language code as defined in IETF RFC 3066.
 
-6.  **MIMEType**<a name="MIMEType"></a>
+6.  ### MIMEType
 
     A simple text value denoting a digital file format as defined in IETF RFC 2046.
 
-7.  **ProperName**<a name="ProperName"></a>
+7.  ### ProperName
 
     A simple text value denoting the name of a person or organization.
 
-8.  **RenditionClass**<a name="RenditionClass"></a>
+8.  ### RenditionClass
 
     A simple text Open Choice value denoting the form or intended usage of a resource. A series of colonseparated (":", U+003A) tokens and parameters, the first of which names the basic usage of the rendition. Additional tokens need not be present; they provide specific characteristics of the rendition.  
 
@@ -112,11 +112,11 @@ This page defines a collection of XMP properties that have broad applicability a
     |thumbnail|A simplified or reduced preview. Additional tokens can provide characteristics. The recommended order is: thumbnail:format:size:colorspace. EXAMPLE thumbnail:jpeg, thumbnail:16x16, thumbnail:gif:8x8:bw.|
 
 
-9.  **URI**<a name="URI"></a>
+9.  ### URI
 
     Text denoting an Internet Uniform Resource Identifier as defined in IETF RFC 3986.
 
-1.  **ResourceRef**<a name="ResourceRef"></a>
+1.  #### ResourceRef
 
     A structure denoting a multiple-component reference to a resource. The field values are taken from various properties in the referenced resource.  
 
@@ -135,15 +135,15 @@ This page defines a collection of XMP properties that have broad applicability a
     |stRef:renditionClass|RenditionClass|The value of the xmpMM:RenditionClass property from the referenced resource.|
     |stRef:renditionParam|Text|The value of the xmpMM:RenditionParams property from the referenced resource.|    
 
-2.  **URL**<a name="URL"></a>
+2.  #### URL
 
     Text denoting an Internet Uniform Resource Locator as defined in URIs, URLs, and URNs: Clarifications and Recommendations.
 
-3.  **Rational**<a name="Rational"></a>
+3.  #### Rational
 
     To represent Exif rational values in XMP, they must be converted to text. The recommended approach is to use a value of type Text of the form numerator /denominator. For example, the value 2/3 becomes the text value "2/3" when converted to XMP.
 
-4.  **FrameRate**<a name="FrameRate"></a>
+4.  #### FrameRate
 
     A frame-rate value can be part of the FrameCount specification of a Marker. For Markers within a Track, however, the frame count can     be a simple integer, and the associated frame rate is specified separately, in the xmpDM:frameRate of the Track.
 
@@ -155,7 +155,7 @@ This page defines a collection of XMP properties that have broad applicability a
     |"f###"|The frame rate in frames-per-second (fps). The rate basis is assumed to be 1. For example, a frame rate of 24fps is specified as “f24”.|
     |"f###s###"|Specifies a frame rate with a rate basis. The second number is the rate basis, a number of seconds. For example, the         NTSC 29.97 frame rate is specified as “f30000s1001”|
     
-5.  **FrameCount**<a name="FrameCount"></a>
+5.  #### FrameCount
     
     A number of frames at a given frame rate, which specifies an audio or video time value for a Marker (as the value of *xmpDM:duration or xmpDM:startTime*). Can also be used in the time portion of a document Part.
     
@@ -169,7 +169,7 @@ This page defines a collection of XMP properties that have broad applicability a
     |"##f###" or "##f###s###"|A number of frames specified together with a FrameRate, which can contain an optional rate basis. The rate basis defaults to 1. These examples show how a FrameCount value of 15 is expressed for common video and audio frame rates: Film at 24 fps (frame rate = 24, rate basis = 1): "15f24", Speech-to-text in milliseconds (frame rate = 1000, rate basis = 1): "15f1000", NTSC at 29.97 fps (frame rate = 30000, rate basis = 1001): "15f30000s1001", DVATicks (frame rate = 254016000000, rate basis = 1): "15f254016000000"|
     |"maximum"|Allowed for a duration value; indicates that the time span is unlimited, or is determined automatically up to the full duration of the source.|
 
-6.  **Part**<a name="Part"></a>
+6.  #### Part
 
     A Unicode string that identifies a portion of a resource. This is typically a general or logical portion, rather than a specific physical portion. For example, the metadata or the content, or the audio portion of a movie or the video portion.
     


### PR DESCRIPTION
https://github.com/showdownjs/showdown/wiki/Showdown's-Markdown-syntax#header-ids
Headers automatically generate anchors with IDs for linking between markdown files.
Please replace <a> tags with headers (#).